### PR TITLE
bug: fail test case for #1

### DIFF
--- a/test.cpp
+++ b/test.cpp
@@ -1,0 +1,15 @@
+#include "lib.h"
+
+int main()
+{
+    bool ans = true;
+    // test sample (issue #1)
+    ans &= maxEven({1, 6, 2, 3, 5, 2, 6, 1, 3}) == 6;
+    // test empty vector
+    ans &= maxEven({}) == -1;
+    if (ans)
+        cout << "Test passed!" << endl;
+    else
+        cout << "Test failed!" << endl;
+    return 0;
+}


### PR DESCRIPTION
Test failed when given an empty vector
```
> g++ -std=c++11 test.cpp lib.cpp -o main && ./main
> zsh: segmentation fault  ./main
```